### PR TITLE
Added --header option

### DIFF
--- a/tasks/livescript.js
+++ b/tasks/livescript.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
       bare: false,
       basePath: false,
       flatten: false,
+      header: true,
       separator: grunt.util.linefeed
     });
 


### PR DESCRIPTION
Currently all output has the `// Generated by LiveScript <version>` header. This change leaves things as-is for existing projects, but if you set `header` to `false` in options, then it will suppress said header.

````js
//...
livescript: {
  options: {
    header: false;
  }
}
//...
````