### PR TITLE
tests on windows + grunt file wildcards

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,18 +36,20 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     livescript: {
       options: {
+        header: false,
         bare: true
       },
       compile: {
         files: {
           'tmp/livescript.js': ['test/fixtures/livescript1.ls'],
           'tmp/concat.js': ['test/fixtures/livescript1.ls', 'test/fixtures/livescript2.ls'],
-          'tmp/individual/*.js': ['test/fixtures/livescript1.ls', 'test/fixtures/livescript2.ls', 'test/fixtures/level2/livescript3.ls']
         }
       },
       flatten: {
         files: {
-          'tmp/individual_flatten/*.js': ['test/fixtures/livescript1.ls', 'test/fixtures/livescript2.ls', 'test/fixtures/level2/livescript3.ls']
+          'tmp/individual_flatten/livescript1.js': 'test/fixtures/livescript1.ls',
+          'tmp/individual_flatten/livescript2.js': 'test/fixtures/livescript2.ls',
+          'tmp/individual_flatten/livescript3.js': 'test/fixtures/level2/livescript3.ls'
         },
         options: {
           flatten: true

--- a/test/livescript_test.js
+++ b/test/livescript_test.js
@@ -1,5 +1,12 @@
+
 var grunt = require('grunt');
-var fs = require('fs');
+
+function read(fileName) {
+  var content = grunt.file.read(fileName);
+  // ensures tests passing on windows
+  content =  content.replace(/\r/g,'');
+  return content;
+}
 
 exports.livescript = {
   compile: function(test) {
@@ -7,12 +14,12 @@ exports.livescript = {
 
     test.expect(2);
 
-    var actual = grunt.file.read('tmp/livescript.js');
-    var expected = grunt.file.read('test/expected/livescript.js');
+    var actual = read('tmp/livescript.js');
+    var expected = read('test/expected/livescript.js');
     test.equal(expected, actual, 'should compile livescript to javascript');
 
-    actual = grunt.file.read('tmp/concat.js');
-    expected = grunt.file.read('test/expected/concat.js');
+    actual = read('tmp/concat.js');
+    expected = read('test/expected/concat.js');
     test.equal(expected, actual, 'should compile multiple livescript files to a single javascript file');
 
     test.done();


### PR DESCRIPTION
Stripped `\r` from compared files to ensure that the tests can be run on windows.

removed header from testfiles to ensure testabillity under different LiveScript versions.

grunt `0.4.5` doesn't like file wildcards à la `"tmp/individual_flatten/*.js"`.